### PR TITLE
fix: netty udp fallback on non-epoll platforms

### DIFF
--- a/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyDatagramMessageProcessor.java
+++ b/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyDatagramMessageProcessor.java
@@ -43,6 +43,7 @@ import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 
 /**
  * Netty Based Datagram Message Processor to handle creation of 
@@ -200,7 +201,7 @@ public class NettyDatagramMessageProcessor extends MessageProcessor implements N
             return EpollDatagramChannel.class;
         } else {
             logger.logWarning("EPoll is not enabled or supported on this platform, using NIO.");
-            return DatagramChannel.class;
+            return NioDatagramChannel.class;
         }
     }    
 }


### PR DESCRIPTION
When running on platform not supporting epoll*, netty processor returns an interface instead of actual implementation, leading to an error:

```
java.lang.NoSuchMethodException: io.netty.channel.socket.DatagramChannel.<init>()
	at java.base/java.lang.Class.getConstructor0(Class.java:3187)
	at java.base/java.lang.Class.getConstructor(Class.java:2199)
	at io.netty.channel.ReflectiveChannelFactory.<init>(ReflectiveChannelFactory.java:34)
	at io.netty.bootstrap.AbstractBootstrap.channel(AbstractBootstrap.java:113)
	at gov.nist.javax.sip.stack.transports.processors.netty.NettyDatagramMessageProcessor.start(NettyDatagramMessageProcessor.java:121)
	at gov.nist.javax.sip.stack.transports.processors.netty.NettyDatagramMessageProcessor.start(NettyDatagramMessageProcessor.java:106)
	at gov.nist.javax.sip.SipStackImpl.createListeningPoint(SipStackImpl.java:1815)
```

(*) EPoll not available on macOS with Apple Silicon
