### PR TITLE
fix: netty udp null requests handling

### DIFF
--- a/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyMessageHandler.java
+++ b/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyMessageHandler.java
@@ -21,6 +21,7 @@ package gov.nist.javax.sip.stack.transports.processors.netty;
 import java.io.IOException;
 
 import javax.sip.ListeningPoint;
+import javax.sip.header.CallIdHeader;
 
 import gov.nist.core.CommonLogger;
 import gov.nist.core.LogLevels;
@@ -81,9 +82,15 @@ public class NettyMessageHandler extends ChannelInboundHandlerAdapter {
                 }
             }
             return;
-        }         
+        }
 
-        final String callId = sipMessage.getCallId().getCallId();
+        CallIdHeader callIdHeader = sipMessage.getCallId();
+        String callId = null;
+
+        if (callIdHeader != null) {
+            callId = callIdHeader.getCallId();
+        }
+
         if (callId == null || callId.trim().length() < 1) {
             // http://code.google.com/p/jain-sip/issues/detail?id=18
             // NIO Message with no Call-ID throws NPE

--- a/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyMessageHandler.java
+++ b/sip-ri/src/main/java/gov/nist/javax/sip/stack/transports/processors/netty/NettyMessageHandler.java
@@ -70,9 +70,16 @@ public class NettyMessageHandler extends ChannelInboundHandlerAdapter {
         	return;
         }
         
-        // RFC5626 CRLF Keep Alive Support
-        if (reliableTransport && sipMessage.isNullRequest()) {
-            processCRLFs(ctx, sipMessage, nettyMessageChannel);
+        if (sipMessage.isNullRequest()) {
+            // RFC5626 CRLF Keep Alive Support
+            if (reliableTransport) {
+                processCRLFs(ctx, sipMessage, nettyMessageChannel);
+            }
+            else {
+                if (logger.isLoggingEnabled(LogWriter.TRACE_DEBUG)) {
+                    logger.logDebug("Ignoring null request over non reliable transport");
+                }
+            }
             return;
         }         
 


### PR DESCRIPTION
### Summary

This PR hardens the Netty SIP message handling path against UDP packets that result in SIP null requests, especially when extra CRLF bytes are received after a valid SIP message body.

A problematic packet shape is:

```plain text
<SIP headers>
Content-Length: N

<body of exactly N bytes>\r\n
```


In this case, the SIP body is complete after exactly `N` bytes. The trailing `\r\n` is outside the SIP message body. The parser can then interpret the remaining CRLF bytes as a separate SIP null request.

Previously, UDP null requests could fall through the normal SIP message processing path. Since null requests do not contain SIP headers such as `Call-ID`, the handler could throw a `NullPointerException` when accessing the Call-ID header.

### Changes

This PR includes two defensive fixes:

1. **Handle SIP null requests before normal message processing**
   - Detects `sipMessage.isNullRequest()` before attempting to access required SIP headers.
   - Keeps existing CRLF keep-alive handling for reliable transports.
   - Ignores CRLF/null requests received over unreliable UDP transport.

2. **Make Call-ID validation null-safe**
   - Avoids calling `getCallId()` on a missing `Call-ID` header.
   - Logs and drops messages with no valid Call-ID instead of throwing an NPE.

### Why

Malformed or non-compliant UDP SIP packets may contain extra CRLF bytes after the message body. For example:

```plain text
<SIP headers>
Content-Length: N

<body of exactly N bytes>\r\n
```


Because `Content-Length` defines the exact body size, the trailing CRLF is not part of the SIP message. When parsed as another message, it becomes a SIP null request without headers.

This PR prevents such packets from crashing the Netty SIP channel and ensures they are safely ignored or rejected.

### Impact

- Prevents `NullPointerException` when receiving UDP CRLF/null requests.
- Improves robustness against malformed SIP UDP datagrams.
- Preserves CRLF keep-alive behavior for reliable transports.
- Drops invalid messages without affecting valid SIP message processing.